### PR TITLE
Use relative_url filter for internal links

### DIFF
--- a/_data/community.yml
+++ b/_data/community.yml
@@ -1,17 +1,17 @@
-- pic: ../assets/images/community/discord.jpg
+- pic: assets/images/community/discord.jpg
   href: https://discord.gg/YxXUVQJ
 
-- pic: ../assets/images/community/reddit.jpg
+- pic: assets/images/community/reddit.jpg
   href: https://www.reddit.com/r/xdag/
 
-- pic: ../assets/images/community/github.jpg
+- pic: assets/images/community/github.jpg
   href: https://github.com/orgs/XDagger
 
-- pic: ../assets/images/community/telegram.jpg
+- pic: assets/images/community/telegram.jpg
   href: https://t.me/dagger_cryptocurrency
 
-- pic: ../assets/images/community/facebook.jpg
+- pic: assets/images/community/facebook.jpg
   href: https://www.facebook.com/XDAG.Dagger.Community/
 
-- pic: ../assets/images/community/twitter.jpg
+- pic: assets/images/community/twitter.jpg
   href: https://twitter.com/XDAG_Community

--- a/_data/dagger.yml
+++ b/_data/dagger.yml
@@ -1,14 +1,14 @@
 - name: CPU/GPU Mineable
   content: XDAG is both CPU & GPU mineable. Making it the first mineable dag project.
-  pic: '../assets/images/about-mining.jpg'
+  pic: 'assets/images/about-mining.jpg'
   delay: 0s
 
 - name: Privacy
   content: XDAG is working on incorporating privacy features. These are part of the 2018 roadmap.
-  pic: '../assets/images/about-mission.jpg'
+  pic: 'assets/images/about-mission.jpg'
   delay: 0.1s
 
 - name: Smart contracts
   content: XDAG is working on the possibility to add smart contract.
-  pic: '../assets/images/about-plan.jpg'
+  pic: 'assets/images/about-plan.jpg'
   delay: 0.2s

--- a/_includes/bannerIndex.html
+++ b/_includes/bannerIndex.html
@@ -3,7 +3,7 @@
         <div id="introCarousel" class="carousel  slide carousel-fade" data-ride="carousel">
             <ol class="carousel-indicators"></ol>
             <div class="carousel-inner" role="listbox">
-                <div class="carousel-item active" style="background-image: url('../assets/images/banner/1.jpg');">
+                <div class="carousel-item active" style="background-image: url({{ 'assets/images/banner/1.jpg' | relative_url }});">
                     <div class="carousel-container">
                         <div class="carousel-content">
                             <h2>XDAG: A new DAG-based<br> cryptocurrency</h2>
@@ -11,7 +11,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="carousel-item " style="background-image: url('../assets/images/banner/2.png');">
+                <div class="carousel-item " style="background-image: url({{ 'assets/images/banner/2.png'  | relative_url }});">
                     <div class="carousel-container">
                         <div class="carousel-content">
                             <h2>The first mineable DAG</h2>
@@ -23,7 +23,7 @@
                     </div>
                 </div>
 
-                <div class="carousel-item" style="background-image: url('../assets/images/banner/3.jpg');">
+                <div class="carousel-item" style="background-image: url({{ 'assets/images/banner/3.jpg'  | relative_url }});">
                     <div class="carousel-container">
                         <div class="carousel-content">
                             <h2>No pre-mine or ICO</h2>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-8 col-md-6 footer-info">
-                    <img src="{{'../assets/images/logo.png'| prepend: site.baseurl | replace: '//', '/' }}" height="40" alt="" title="" />
+                    <img src="{{ '/assets/images/logo.png' | relative_url }}" height="40" alt="" title="" />
                     <div class="btm">
                         <p>Support The Community: This site is managed by the XDAG community.</p>
                         <p class="btmWallet">Contribute XDAG: {{site.offical}}</p>
@@ -13,14 +13,14 @@
                 <div class="col-lg-4 col-md-6 footer-links">
                     <h4>Useful Links</h4>
                     <ul>
-                        <li><i class="ion-ios-arrow-right"></i> <a href="{{'index.html'| prepend: site.baseurl | replace: '//', '/' }}">Home</a></li>
+                        <li><i class="ion-ios-arrow-right"></i> <a href="{{ 'index.html' | relative_url }}">Home</a></li>
                         <li><i class="ion-ios-arrow-right"></i> <a href="http://explorer.xdag.io/" target="_blank">Block explorer</a></li>
                         <!--<li><i class="ion-ios-arrow-right"></i> <a href="#">Forum</a></li>-->
                         <!--<li><i class="ion-ios-arrow-right"></i> <a href="#">Blog</a></li>-->
                         <!--<li><i class="ion-ios-arrow-right"></i> <a href="#">Wiki</a></li>-->
-                        <li><i class="ion-ios-arrow-right"></i> <a href="{{'index.html#services'| prepend: site.baseurl | replace: '//', '/' }}">MINING QUICK START</a></li>
-                        <li><i class="ion-ios-arrow-right"></i> <a href="{{'index.html#wallet'| prepend: site.baseurl | replace: '//', '/' }}">WALLETS</a></li>
-                        <li><i class="ion-ios-arrow-right"></i> <a href="{{'blog/index.html'| prepend: site.baseurl | replace: '//', '/' }}">NEWS</a></li>
+                        <li><i class="ion-ios-arrow-right"></i> <a href="{{ 'index.html#services' | relative_url }}">MINING QUICK START</a></li>
+                        <li><i class="ion-ios-arrow-right"></i> <a href="{{ 'index.html#wallet' | relative_url }}">WALLETS</a></li>
+                        <li><i class="ion-ios-arrow-right"></i> <a href="{{ 'blog/index.html' | relative_url }}">NEWS</a></li>
                         <!--<li><i class="ion-ios-arrow-right"></i> <a href="{{'index.html#roadmap'| prepend: site.baseurl | replace: '//', '/' }}">ROADMAP</a></li>-->
                     </ul>
                 </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,20 +1,20 @@
 <header id="header">
     <div class="container-fluid">
         <div id="logo" class="pull-left">
-            <a href="#intro"><img src="{{'../assets/images/logo.png'| prepend: site.baseurl | replace: '//', '/' }}" height="40" alt="" title="" /></a>
+            <a href="#intro"><img src="{{ 'assets/images/logo.png' | relative_url }}" height="40" alt="" title="" /></a>
         </div>
 
         <nav id="nav-menu-container">
             <ul class="nav-menu">
-                <li ><a href="{{'index.html'| prepend: site.baseurl | replace: '//', '/' }}">Home</a></li>
+                <li ><a href="{{ 'index.html' | relative_url }}">Home</a></li>
                 <li><a href="http://explorer.xdag.io/" target="_blank">Block explorer</a></li>
                 <!--<li><a href="team.html">Team</a></li>-->
                 <!--<li><a href="#">Forum</a></li>-->
                 <!--<li><a href="#">Blog</a></li>-->
                 <!--<li><a href="#">Wiki</a></li>-->
-                <li><a href="{{'index.html#services'| prepend: site.baseurl | replace: '//', '/' }}">MINING QUICK START</a></li>
-                <li><a href="{{'index.html#wallet'| prepend: site.baseurl | replace: '//', '/' }}">WALLETS</a></li>
-                <li><a href="{{'../blog/index.html'| prepend: site.baseurl | replace: '//', '/' }}">NEWS</a></li>
+                <li><a href="{{ 'index.html#services' | relative_url }}">MINING QUICK START</a></li>
+                <li><a href="{{ 'index.html#wallet' | relative_url }}">WALLETS</a></li>
+                <li><a href="{{ 'blog/index.html' | relative_url }}">NEWS</a></li>
                 <!--<li><a href="{{'index.html#roadmap'| prepend: site.baseurl | replace: '//', '/' }}">ROADMAP</a></li>-->
             </ul>
         </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,16 +7,16 @@
     <meta content="{{site.index_keywords}}" name="keywords">
     <meta content="{{site.index_description}}" name="description">
 
-    <link href="../assets/images/fav/favicon.png" rel="icon">
-    <link href="../assets/images/fav/apple-touch-icon.png" rel="apple-touch-icon">
+    <link href="{{ 'assets/images/fav/favicon.png' | relative_url }}" rel="icon">
+    <link href="{{ 'assets/images/fav/apple-touch-icon.png' | relative_url }}" rel="apple-touch-icon">
 
-    <link href="../assets/lib/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-    <link href="../assets/lib/font-awesome/css/font-awesome.min.css" rel="stylesheet">
-    <link href="../assets/lib/animate/animate.css" rel="stylesheet">
-    <link href="../assets/lib/ionicons/css/ionicons.min.css" rel="stylesheet">
-    <link href="../assets/lib/owlcarousel/assets/owl.carousel.min.css" rel="stylesheet">
-    <link href="../assets/lib/lightbox/css/lightbox.min.css" rel="stylesheet">
-    <link href="../css/index.css" rel="stylesheet">
+    <link href="{{ 'assets/lib/bootstrap/css/bootstrap.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/font-awesome/css/font-awesome.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/animate/animate.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/ionicons/css/ionicons.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/owlcarousel/assets/owl.carousel.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/lightbox/css/lightbox.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'css/index.css' | relative_url }}" rel="stylesheet">
 </head>
 <body>
 {% include header.html %}
@@ -38,7 +38,7 @@
                 <div class="col-md-4 wow fadeInUp" data-wow-delay="{{d.delay}}">
                     <div class="about-col">
                         <div class="img">
-                            <img src="{{d.pic}}" alt="" class="img-fluid">
+                            <img src="{{ d.pic | relative_url }}" alt="" class="img-fluid">
                             <div class="icon"><i class="ion-ios-unlocked-outline"></i></div>
                         </div>
                         <h2 class="title">{{ d.name }}</h2>
@@ -75,8 +75,7 @@
                             <p class="pStrong">Fee&nbsp;explanation:</p>
                             <hr />
                             <p >For example: IP | (
-                                <span class="purple">1%<sup><span class="brdr"><span class="sup">1</span></span></sup>
-</span> -
+                                <span class="purple">1%<sup><span class="brdr"><span class="sup">1</span></span></sup></span> -
                                 <span class="black">1%<sup><span class="brdr"><span class="sup">2</span></span></sup></span> -
                                 <span class="dark">1%<sup><span class="brdr"><span class="sup">3</span></span></sup></span> -
                                 <span class="blue">1%<sup><span class="brdr"><span class="sup">4</span></span></sup></span>) | Pool Location | (Pool link) | Pool Owner</p>
@@ -151,7 +150,7 @@
             </header>
             <div class="owl-carousel clients-carousel">
                 {% for d in site.data.community %}
-                <a href="{{ d.href }}" target="_blank"><img src="{{ d.pic }}" alt=""></a>
+                <a href="{{ d.href }}" target="_blank"><img src="{{ d.pic | relative_url }}" alt=""></a>
                 {% endfor %}
             </div>
         </div>
@@ -160,18 +159,18 @@
 {% include footer.html %}
 <a href="#" class="back-to-top"><i class="fa fa-chevron-up"></i></a>
 
-<script src="../assets/lib/jquery/jquery.min.js"></script>
-<script src="../assets/lib/jquery/jquery-migrate.min.js"></script>
-<script src="../assets/lib/bootstrap/js/bootstrap.bundle.min.js"></script>
-<script src="../assets/lib/easing/easing.min.js"></script>
-<script src="../assets/lib/superfish/hoverIntent.js"></script>
-<script src="../assets/lib/superfish/superfish.min.js"></script>
-<script src="../assets/lib/wow/wow.min.js"></script>
-<script src="../assets/lib/waypoints/waypoints.min.js"></script>
-<script src="../assets/lib/owlcarousel/owl.carousel.min.js"></script>
-<script src="../assets/lib/lightbox/js/lightbox.min.js"></script>
-<script src="../assets/lib/touchSwipe/jquery.touchSwipe.min.js"></script>
-<script src="../assets/js/public.js"></script>
-<script src="../assets/js/main.js"></script>
+<script src="{{ 'assets/lib/jquery/jquery.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/jquery/jquery-migrate.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/bootstrap/js/bootstrap.bundle.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/easing/easing.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/superfish/hoverIntent.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/superfish/superfish.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/wow/wow.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/waypoints/waypoints.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/owlcarousel/owl.carousel.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/lightbox/js/lightbox.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/touchSwipe/jquery.touchSwipe.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/js/public.js' | relative_url }}"></script>
+<script src="{{ 'assets/js/main.js' | relative_url }}"></script>
 </body>
 </html>

--- a/_layouts/newsLayout.html
+++ b/_layouts/newsLayout.html
@@ -30,7 +30,7 @@
                 {% for post in paginator.posts  %}
                     <li>
                         <div class="lft">
-                            <div class="tit"> <a href="{{post.url}}">{{ post.title }}</a><i class="ion-ios-arrow-down"></i></div>
+                            <div class="tit"> <a href="{{ post.url | relative_url }}">{{ post.title }}</a><i class="ion-ios-arrow-down"></i></div>
                             <div class="cont all">{{ post.content }}</div>
                             <div class="cont h60 top">{{ post.excerpt | strip_html }}</div>
                         </div>

--- a/_layouts/newsLayout.html
+++ b/_layouts/newsLayout.html
@@ -6,37 +6,16 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <meta content="" name="keywords">
     <meta content="" name="description">
-    <link href="../../assets/images/fav/favicon.png" rel="icon">
-    <link href="../../assets/images/fav/apple-touch-icon.png" rel="apple-touch-icon">
-    <link href="../../assets/lib/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-    <link href="../../assets/lib/font-awesome/css/font-awesome.min.css" rel="stylesheet">
-    <link href="../../assets/lib/ionicons/css/ionicons.min.css" rel="stylesheet">
-    <link href="../../assets/lib/animate/animate.css" rel="stylesheet" >
-    <link href="../../css/news.css" rel="stylesheet" >
+    <link href="{{ 'assets/images/fav/favicon.png' | relative_url }}" rel="icon">
+    <link href="{{ 'assets/images/fav/apple-touch-icon.png' | relative_url }}" rel="apple-touch-icon">
+    <link href="{{ 'assets/lib/bootstrap/css/bootstrap.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/font-awesome/css/font-awesome.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/ionicons/css/ionicons.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/animate/animate.css' | relative_url }}" rel="stylesheet" >
+    <link href="{{ 'css/news.css' | relative_url }}" rel="stylesheet" >
 </head>
 <body>
-<header id="header">
-    <div class="container-fluid">
-        <div id="logo" class="pull-left">
-            <a href="#intro"><img src="../../assets/images/logo.png" height="40" alt="" title="" /></a>
-        </div>
-
-        <nav id="nav-menu-container">
-            <ul class="nav-menu">
-                <li ><a href="../../index.html">Home</a></li>
-                <li><a href="http://explorer.xdag.io/" target="_blank">Block explorer</a></li>
-                <!--<li><a href="team.html">Team</a></li>-->
-                <!--<li><a href="#">Forum</a></li>-->
-                <!--<li><a href="#">Blog</a></li>-->
-                <!--<li><a href="#">Wiki</a></li>-->
-                <li><a href="../../index.html#services">MINING QUICK START</a></li>
-                <li><a href="../../index.html#wallet">WALLETS</a></li>
-                <li><a href="../blog/index.html">NEWS</a></li>
-                <!--<li><a href="../../index.html#roadmap">ROADMAP</a></li>-->
-            </ul>
-        </nav>
-    </div>
-</header>
+{% include header.html %}
 <div id="intro"></div>
 <main id="main">
     <section id="news">
@@ -66,7 +45,7 @@
                 {% if paginator.total_pages > 1 %}
                 <div class="pagination">
                     {% if paginator.previous_page %}
-                    <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="prev">Previous</a>
+                    <a href="{{ paginator.previous_page_path | relative_url }}" class="prev">Previous</a>
                     {% else %}
                     <span>Previous</span>
 
@@ -75,14 +54,14 @@
                     {% if page == paginator.page %}
                     <em>{{ page }}</em>
                     {% elsif page == 1 %}
-                    <a href="{{ '/blog/index.html' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+                    <a href="{{ '/blog/index.html' | relative_url }}">{{ page }}</a>
                     {% else %}
-                    <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
+                    <a href="{{ site.paginate_path | relative_url | replace: ':num', page }}">{{ page }}</a>
                     {% endif %}
                     {% endfor %}
 
                     {% if paginator.next_page %}
-                    <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Next</a>
+                    <a href="{{ paginator.next_page_path | relative_url }}">Next</a>
                     {% else %}
                     <span>Next</span>
                     {% endif %}
@@ -98,7 +77,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-8 col-md-6 footer-info">
-                    <img src="../../assets/images/logo.png" height="40" alt="" title="" />
+                    <img src="{{ 'assets/images/logo.png' | relative_url }}" height="40" alt="" title="" />
                     <div class="btm">
                         <p>Support The Community: This site is managed by the XDAG community.</p>
                         <p class="btmWallet">Contribute XDAG: {{site.offical}}</p>
@@ -108,15 +87,15 @@
                 <div class="col-lg-4 col-md-6 footer-links">
                     <h4>Useful Links</h4>
                     <ul>
-                        <li><i class="ion-ios-arrow-right"></i> <a href="../../index.html">Home</a></li>
+                        <li><i class="ion-ios-arrow-right"></i> <a href="{{ 'index.html' | relative_url }}">Home</a></li>
                         <li><i class="ion-ios-arrow-right"></i> <a href="http://explorer.xdag.io/" target="_blank">Block explorer</a></li>
                         <!--<li><i class="ion-ios-arrow-right"></i> <a href="#">Forum</a></li>-->
                         <!--<li><i class="ion-ios-arrow-right"></i> <a href="#">Blog</a></li>-->
                         <!--<li><i class="ion-ios-arrow-right"></i> <a href="#">Wiki</a></li>-->
-                        <li><i class="ion-ios-arrow-right"></i> <a href="../../index.html#services">MINING QUICK START</a></li>
-                        <li><i class="ion-ios-arrow-right"></i> <a href="../../index.html#wallet">WALLETS</a></li>
+                        <li><i class="ion-ios-arrow-right"></i> <a href="{{ 'index.html#services' | relative_url }}">MINING QUICK START</a></li>
+                        <li><i class="ion-ios-arrow-right"></i> <a href="{{ 'index.html#wallet' | relative_url }}">WALLETS</a></li>
                         <!--<li><i class="ion-ios-arrow-right"></i> <a href="{{'blog/index.html'| prepend: site.baseurl | replace: '//', '/' }}">NEWS</a></li>-->
-                        <li><i class="ion-ios-arrow-right"></i> <a href="../../index.html#roadmap">ROADMAP</a></li>
+                        <li><i class="ion-ios-arrow-right"></i> <a href="{{ 'index.html#roadmap' | relative_url }}">ROADMAP</a></li>
                     </ul>
                 </div>
             </div>
@@ -124,14 +103,14 @@
     </div>
 </footer>
 <a href="#" class="back-to-top"><i class="fa fa-chevron-up"></i></a>
-<script src="../../assets/lib/jquery/jquery.min.js"></script>
-<script src="../../assets/lib/jquery/jquery-migrate.min.js"></script>
-<script src="../../assets/lib/bootstrap/js/bootstrap.bundle.min.js"></script>
-<script src="../../assets/lib/easing/easing.min.js"></script>
-<script src="../../assets/lib/superfish/hoverIntent.js"></script>
-<script src="../../assets/lib/superfish/superfish.min.js"></script>
-<script src="../../assets/lib/wow/wow.min.js"></script>
-<script src="../../assets/js/public.js"></script>
-<script src="../../assets/js/news.js"></script>
+<script src="{{ 'assets/lib/jquery/jquery.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/jquery/jquery-migrate.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/bootstrap/js/bootstrap.bundle.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/easing/easing.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/superfish/hoverIntent.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/superfish/superfish.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/wow/wow.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/js/public.js' | relative_url }}"></script>
+<script src="{{ 'assets/js/news.js' | relative_url }}"></script>
 </body>
 </html>

--- a/_layouts/postLayout.html
+++ b/_layouts/postLayout.html
@@ -7,37 +7,16 @@
     <meta content="" name="keywords">
     <meta content="" name="description">
     <meta name="twitter:card" content="summary"></meta>
-    <link href="../../../assets/images/fav/favicon.png" rel="icon">
-    <link href="../../../assets/images/fav/apple-touch-icon.png" rel="apple-touch-icon">
-    <link href="../../../assets/lib/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-    <link href="../../../assets/lib/font-awesome/css/font-awesome.min.css" rel="stylesheet">
-    <link href="../../../assets/lib/ionicons/css/ionicons.min.css" rel="stylesheet">
-    <link href="../../../assets/lib/animate/animate.css" rel="stylesheet" >
-    <link href="../../../css/news.css" rel="stylesheet" >
+    <link href="{{ 'assets/images/fav/favicon.png' | relative_url }}" rel="icon">
+    <link href="{{ 'assets/images/fav/apple-touch-icon.png' | relative_url }}" rel="apple-touch-icon">
+    <link href="{{ 'assets/lib/bootstrap/css/bootstrap.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/font-awesome/css/font-awesome.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/ionicons/css/ionicons.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/animate/animate.css' | relative_url }}" rel="stylesheet" >
+    <link href="{{ 'css/news.css' | relative_url }}" rel="stylesheet" >
 </head>
 <body>
-<header id="header">
-    <div class="container-fluid">
-        <div id="logo" class="pull-left">
-            <a href="../../../index.html"><img src="../../../assets/images/logo.png" height="40" alt="" title="" /></a>
-        </div>
-
-        <nav id="nav-menu-container">
-            <ul class="nav-menu">
-                <li ><a href="../../../index.html">Home</a></li>
-                <li><a href="http://explorer.xdag.io/" target="_blank">Block explorer</a></li>
-                <!--<li><a href="team.html">Team</a></li>-->
-                <!--<li><a href="#">Forum</a></li>-->
-                <!--<li><a href="#">Blog</a></li>-->
-                <!--<li><a href="#">Wiki</a></li>-->
-                <li><a href="../../../index.html#services">MINING QUICK START</a></li>
-                <li><a href="../../../index.html#wallet">WALLETS</a></li>
-                <li><a href="../../../blog/index.html">NEWS</a></li>
-                <!--<li><a href="../../index.html#roadmap">ROADMAP</a></li>-->
-            </ul>
-        </nav>
-    </div>
-</header>
+{% include header.html %}
 <div id="intro"></div>
 <main id="main">
     <section id="news">
@@ -88,14 +67,14 @@
     </div>
 </footer>
 <a href="#" class="back-to-top"><i class="fa fa-chevron-up"></i></a>
-<script src="../../../assets/lib/jquery/jquery.min.js"></script>
-<script src="../../../assets/lib/jquery/jquery-migrate.min.js"></script>
-<script src="../../../assets/lib/bootstrap/js/bootstrap.bundle.min.js"></script>
-<script src="../../../assets/lib/easing/easing.min.js"></script>
-<script src="../../../assets/lib/superfish/hoverIntent.js"></script>
-<script src="../../../assets/lib/superfish/superfish.min.js"></script>
-<script src="../../../assets/lib/wow/wow.min.js"></script>
-<script src="../../../assets/js/public.js"></script>
-<script src="../../../assets/js/news.js"></script>
+<script src="{{ 'assets/lib/jquery/jquery.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/jquery/jquery-migrate.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/bootstrap/js/bootstrap.bundle.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/easing/easing.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/superfish/hoverIntent.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/superfish/superfish.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/wow/wow.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/js/public.js' | relative_url }}"></script>
+<script src="{{ 'assets/js/news.js' | relative_url }}"></script>
 </body>
 </html>

--- a/_layouts/teamLayout.html
+++ b/_layouts/teamLayout.html
@@ -6,12 +6,12 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <meta content="" name="keywords">
     <meta content="" name="description">
-    <link href="../assets/images/fav/favicon.png" rel="icon">
-    <link href="../assets/images/fav/apple-touch-icon.png" rel="apple-touch-icon">
-    <link href="../assets/lib/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-    <link href="../assets/lib/font-awesome/css/font-awesome.min.css" rel="stylesheet">
-    <link href="../assets/lib/animate/animate.css" rel="stylesheet">
-    <link href="../css/team.css" rel="stylesheet">
+    <link href="{{ 'assets/images/fav/favicon.png' | relative_url }}" rel="icon">
+    <link href="{{ 'assets/images/fav/apple-touch-icon.png' | relative_url }}" rel="apple-touch-icon">
+    <link href="{{ 'assets/lib/bootstrap/css/bootstrap.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/font-awesome/css/font-awesome.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'assets/lib/animate/animate.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ 'css/team.css' | relative_url }}" rel="stylesheet">
 </head>
 
 <body>
@@ -57,16 +57,16 @@
 </main>
 {% include footer.html %}
 <a href="#" class="back-to-top"><i class="fa fa-chevron-up"></i></a>
-<script src="../assets/lib/jquery/jquery.min.js"></script>
-<script src="../assets/lib/jquery/jquery-migrate.min.js"></script>
-<script src="../assets/lib/bootstrap/js/bootstrap.bundle.min.js"></script>
-<script src="../assets/lib/easing/easing.min.js"></script>
-<script src="../assets/lib/superfish/hoverIntent.js"></script>
-<script src="../assets/lib/superfish/superfish.min.js"></script>
-<script src="../assets/lib/wow/wow.min.js"></script>
-<script src="../assets/lib/waypoints/waypoints.min.js"></script>
-<script src="../assets/lib/counterup/counterup.min.js"></script>
-<script src="../assets/js/public.js"></script>
-<script src="../assets/js/team.js"></script>
+<script src="{{ 'assets/lib/jquery/jquery.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/jquery/jquery-migrate.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/bootstrap/js/bootstrap.bundle.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/easing/easing.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/superfish/hoverIntent.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/superfish/superfish.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/wow/wow.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/waypoints/waypoints.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/lib/counterup/counterup.min.js' | relative_url }}"></script>
+<script src="{{ 'assets/js/public.js' | relative_url }}"></script>
+<script src="{{ 'assets/js/team.js' | relative_url }}"></script>
 </body>
 </html>


### PR DESCRIPTION
By using relative_url filter we can avoid worrying about traversing '../../..' when using any internal links.

"Relative URL
Prepend the baseurl value to the input. Useful if your site is hosted at a subpath rather than the root of the domain."

https://jekyllrb.com/docs/templates/
The baseurl can be edited from _config.yml