### PR TITLE
Fix/change default word breaking to remove horizontal scrollbars in smaller screens

### DIFF
--- a/_sass/indexStyle.scss
+++ b/_sass/indexStyle.scss
@@ -5,6 +5,8 @@ body {
   background: #fff;
   color: #666666;
   font-family: "Open Sans", sans-serif;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 a {
@@ -2020,7 +2022,6 @@ $vline-spacing: 10px;
 }
 .btm{
   padding-top:40px;
-  word-wrap:break-word;
 }
 .btmWallet{
   font-size: 16px!important;

--- a/_sass/newsStyle.scss
+++ b/_sass/newsStyle.scss
@@ -895,6 +895,10 @@ ul,li{
   }
 }
 @media (max-width: 768px) {
+  .news > li {
+    display: block;
+  }
+
   .lft,.rht{
   display: block!important;
   }

--- a/_sass/newsStyle.scss
+++ b/_sass/newsStyle.scss
@@ -5,6 +5,8 @@ body {
   background: #fff;
   color: #666666;
   font-family: "Open Sans", sans-serif;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 a {

--- a/_sass/teamstyle.scss
+++ b/_sass/teamstyle.scss
@@ -5,6 +5,8 @@ body {
   background: #fff;
   color: #666666;
   font-family: "Open Sans", sans-serif;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 a {


### PR DESCRIPTION
We could also use `word-break: break-word;` instead of `overflow-wrap: break-word;`, this would fix the issue for even smaller screen sizes without additional changes. Difference is that word-break would break words all they way until a single-letter is left. It might be better to just modify the problem area's design to take into account such low screen dimensions.

This area breaks at 305px with overflow-wrap. Though in my opinion we don't need to worry about sizes lower than 320px.

overflow-wrap
![overflow-wrap](https://user-images.githubusercontent.com/31631352/39663574-49e494a2-507e-11e8-8f9e-6dd2be78197a.PNG)

word-break
![word-break](https://user-images.githubusercontent.com/31631352/39663576-4ff5d7f2-507e-11e8-8243-3a17d6e80d24.PNG)


